### PR TITLE
Fix `golangci-lint` issues and warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,27 +22,22 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - errcheck
     - goconst
     - gocritic
     - gofmt
     - goimports
-    - golint
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - misspell
     - nakedret
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:

--- a/provider.go
+++ b/provider.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/open-policy-agent/frameworks/constraint/pkg/externaldata"
@@ -36,7 +37,14 @@ func main() {
 	fmt.Println("starting server...")
 	http.HandleFunc("/validate", validate)
 
-	if err := http.ListenAndServe(":8090", nil); err != nil {
+	srv := &http.Server{
+		Addr:              ":8090",
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Mathieu Benoit <mathieu-benoit@hotmail.fr>

Fixing: https://github.com/sigstore/cosign-gatekeeper-provider/issues/22.

FYI, resources in this Org related to this (specifically around the value: `10 * time.Second`):
- https://github.com/sigstore/fulcio/pull/735
- https://github.com/sigstore/cosign/blob/main/test/cmd/getoidctoken/main.go#L57

Also took the initiative to fix the following warnings by removing the deprecated linters now included in the `unused` linter:
```
level=warning msg="[runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
  level=warning msg="[runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive."
  level=warning msg="[runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
  level=warning msg="[runner] The linter 'interfacer' is deprecated (since v1.38.0) due to: The repository of the linter has been archived by the owner. "
  level=warning msg="[runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused."
```

Finally, took also the initiative to fix the following warning by using `golangci/golangci-lint-action` `v3`:
```
Warning: The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```