### PR TITLE
go 1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.20.x]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/check-headers.yml
+++ b/.github/workflows/check-headers.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.20.x]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.20.x]
 
     runs-on: ubuntu-latest
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILDPLATFORM="linux/amd64"
-ARG BUILDERIMAGE="golang:1.17"
+ARG BUILDERIMAGE="golang:1.20"
 ARG BASEIMAGE="gcr.io/distroless/static:nonroot"
 
 FROM --platform=$BUILDPLATFORM $BUILDERIMAGE as builder

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sigstore/cosign-gatekeeper-provider
 
-go 1.17
+go 1.20
 
 require (
 	github.com/google/go-containerregistry v0.6.1-0.20210922191434-34b7f00d7a60


### PR DESCRIPTION
Signed-off-by: Mathieu Benoit <mathieu-benoit@hotmail.fr>

Update go from 1.17 to [1.20](https://go.dev/blog/go1.20).

Tested with the new container image deployed in my Kuberentes cluster, same behavior than with the previous image.

The container image built went from 33 vulnerabilities down to 8. Here are the vulnerabilities fixed:
```
CVE-2022-23806 	 Critical	6.4	Yes	go	Go stdlib		
CVE-2022-23772 	 High	7.8	Yes	go	Go stdlib		
CVE-2022-30631 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-41715 	 High	7.5	Yes	go	Go stdlib	
CVE-2022-32189 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-28327 	 High	5	Yes	go	Go stdlib		
CVE-2022-30632 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-2880 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-23773 	 High	5	Yes	go	Go stdlib		
CVE-2022-30630 	 High	7.5	Yes	go	Go stdlib	
CVE-2022-28131 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-30633 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-2879 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-30635 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-27664 	 High	7.5	Yes	go	Go stdlib		
CVE-2022-24921 	 High	5	Yes	go	Go stdlib		
CVE-2021-44716 	 High	5	Yes	go	Go stdlib		
CVE-2022-24675 	 High	5	Yes	go	Go stdlib		
CVE-2022-30580 	 High	7.8	Yes	go	Go stdlib		
CVE-2022-1962 	 Medium	5.5	Yes	go	Go stdlib		
CVE-2022-1705 	 Medium	6.5	Yes	go	Go stdlib		
CVE-2022-41717 	 Medium	5.3	Yes	go	Go stdlib		
CVE-2022-32148 	 Medium	6.5	Yes	go	Go stdlib		
CVE-2022-30629 	 Low	3.1	Yes	go	Go stdlib
```

Note that other sigstore projects are already in go 1.20:
- https://github.com/sigstore/rekor/blob/main/Dockerfile#L16
- https://github.com/sigstore/fulcio/blob/main/Dockerfile#L16