### PR TITLE
Gatekeeper setup: `insecureTLSSkipVerify: true` to work with current state `alpha` and `http`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ helm install gatekeeper/gatekeeper  \
     --name-template=gatekeeper \
     --namespace gatekeeper-system --create-namespace \
     --set enableExternalData=true \
-    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst
+    --set controllerManager.dnsPolicy=ClusterFirst,audit.dnsPolicy=ClusterFirst \
+    --version 3.10.0
 ```
+_Note: This repository is currently only working with Gatekeeper 3.10 and the `externalData` feature in `alpha`. There is an open issue to track the support of Gatekeeper 3.11 and `externalData` feature in `beta`: https://github.com/sigstore/cosign-gatekeeper-provider/issues/20._
 
 Let's install the `cosign-gatekeeper-provider`:
 

--- a/manifest/provider.yaml
+++ b/manifest/provider.yaml
@@ -5,3 +5,4 @@ metadata:
 spec:
   url: http://cosign-gatekeeper-provider.cosign-gatekeeper-provider:8090/validate
   timeout: 30
+  insecureTLSSkipVerify: true


### PR DESCRIPTION
Signed-off-by: Mathieu Benoit <mathieu-benoit@hotmail.fr>

Proposing to have the current state of this repo working with `alpha` and `http` by adding the `insecureTLSSkipVerify: true` parameter.

Here are the errors fixed with that:
- If installing Gatekeeper 3.11 (`latest` as we speak), getting this error: https://github.com/sigstore/cosign-gatekeeper-provider/issues/20.
- If installing Gatekeeper 3.10, getting this error below:
```
"manifest/provider.yaml": error when patching "manifest/provider.yaml": admission webhook "validation.gatekeeper.sh" denied the request: only HTTPS scheme is supported for this Provider. To enable HTTP scheme, set insecureTLSSkipVerify to true
```

Also adding an explicit note and instruction to install Gatekeeper 3.10 to have this project working until https://github.com/sigstore/cosign-gatekeeper-provider/issues/20 is fixed and implemented. Otherwise, nobody can use this project with Gatekeeper 3.11. So this PR is temporary workaround of the Gatekeeper setup.


**Important note: even after this setup, there is another issue related to https://github.com/sigstore/cosign-gatekeeper-provider/issues/16 when trying to deploy both scenarios: signed or unsigned containers. But that's not related to what this PR is trying to fix/propose here.**